### PR TITLE
Adding headers in the share data functionality

### DIFF
--- a/Snooper/src/main/java/com/prateekj/snooper/networksnooper/helper/DataCopyHelper.java
+++ b/Snooper/src/main/java/com/prateekj/snooper/networksnooper/helper/DataCopyHelper.java
@@ -84,7 +84,7 @@ public class DataCopyHelper {
       dataToCopy.append("\n");
       dataToCopy.append(formattedResponseData);
     }
-    appendHeaders(httpCallRecord.getRequestHeaders(), dataToCopy, "Response Headers");
+    appendHeaders(httpCallRecord.getResponseHeaders(), dataToCopy, "Response Headers");
   }
 
   private String getFormattedData(HttpHeader contentTypeHeader, String dataToCopy) {

--- a/Snooper/src/main/java/com/prateekj/snooper/networksnooper/helper/DataCopyHelper.java
+++ b/Snooper/src/main/java/com/prateekj/snooper/networksnooper/helper/DataCopyHelper.java
@@ -1,12 +1,18 @@
 package com.prateekj.snooper.networksnooper.helper;
 
+import com.google.common.base.Function;
 import com.prateekj.snooper.formatter.ResponseFormatter;
 import com.prateekj.snooper.formatter.ResponseFormatterFactory;
 import com.prateekj.snooper.networksnooper.model.HttpCallRecord;
 import com.prateekj.snooper.networksnooper.model.HttpHeader;
+import com.prateekj.snooper.networksnooper.model.HttpHeaderValue;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Iterator;
+import java.util.List;
+
+import static com.google.common.collect.Collections2.transform;
 import static com.prateekj.snooper.networksnooper.model.HttpHeader.CONTENT_TYPE;
 
 public class DataCopyHelper {
@@ -33,14 +39,44 @@ public class DataCopyHelper {
   public StringBuilder getHttpCallData() {
     StringBuilder dataToCopy = new StringBuilder();
 
+    appendRequestData(dataToCopy);
+    appendResponseData(dataToCopy);
+    return dataToCopy;
+  }
+
+  private void appendRequestData(StringBuilder dataToCopy) {
     String formattedRequestData = getRequestDataForCopy();
     if (!StringUtils.isEmpty(formattedRequestData)) {
       dataToCopy.append("Request Body");
       dataToCopy.append("\n");
       dataToCopy.append(formattedRequestData);
-      dataToCopy.append("\n");
     }
+    appendHeaders(httpCallRecord.getRequestHeaders(), dataToCopy, "Request Headers");
+  }
 
+  private void appendHeaders(List<HttpHeader> headers, StringBuilder dataToCopy, String heading) {
+    if (headers != null && !headers.isEmpty()) {
+      dataToCopy.append("\n");
+      dataToCopy.append(heading);
+      dataToCopy.append("\n");
+      for (HttpHeader header : headers) {
+        dataToCopy.append(header.getName() + ": ");
+        dataToCopy.append(StringUtils.join(toHeaderValues(header), ";"));
+        dataToCopy.append("\n");
+      }
+    }
+  }
+
+  private Iterator<String> toHeaderValues(HttpHeader httpHeader) {
+    return transform(httpHeader.getValues(), new Function<HttpHeaderValue, String>() {
+      @Override
+      public String apply(HttpHeaderValue headerValue) {
+        return headerValue.getValue();
+      }
+    }).iterator();
+  }
+
+  private void appendResponseData(StringBuilder dataToCopy) {
     String formattedResponseData = getResponseDataForCopy();
 
     if (!StringUtils.isEmpty(formattedResponseData)) {
@@ -48,7 +84,7 @@ public class DataCopyHelper {
       dataToCopy.append("\n");
       dataToCopy.append(formattedResponseData);
     }
-    return dataToCopy;
+    appendHeaders(httpCallRecord.getRequestHeaders(), dataToCopy, "Response Headers");
   }
 
   private String getFormattedData(HttpHeader contentTypeHeader, String dataToCopy) {

--- a/Snooper/src/test/java/com/prateekj/snooper/networksnooper/helper/DataCopyHelperTest.java
+++ b/Snooper/src/test/java/com/prateekj/snooper/networksnooper/helper/DataCopyHelperTest.java
@@ -150,7 +150,7 @@ public class DataCopyHelperTest {
     when(httpCall.getRequestHeaders()).thenReturn(asList(httpHeader, getJsonContentTypeHeader()));
     when(httpCall.getRequestHeader("Content-Type")).thenReturn(getJsonContentTypeHeader());
     when(httpCall.getPayload()).thenReturn(requestBody);
-    when(httpCall.getResponseHeaders()).thenReturn(asList(httpHeader, getJsonContentTypeHeader()));
+    when(httpCall.getResponseHeaders()).thenReturn(asList(httpHeader, getHeader()));
     when(httpCall.getResponseHeader("Content-Type")).thenReturn(getJsonContentTypeHeader());
     when(httpCall.getResponseBody()).thenReturn(responseBody);
     when(httpCall.getDate()).thenReturn(getDate(2017, 4, 12, 1, 2, 3));
@@ -162,7 +162,7 @@ public class DataCopyHelperTest {
 
     assertThat(httpCallData.toString(), is("Request Body\nformat Request body\nRequest Headers\naccept-language: en-US," +
       "en;q=0.8,hi;q=0.6\nContent-Type: application/json\nResponse Body\nformat Response body\nResponse Headers\n" +
-      "accept-language: en-US,en;q=0.8,hi;q=0.6\nContent-Type: application/json\n"));
+      "accept-language: en-US,en;q=0.8,hi;q=0.6\nHeader: headerValue\n"));
     verify(responseFormatter, times(1)).format(requestBody);
     verify(responseFormatter, times(1)).format(responseBody);
   }
@@ -207,6 +207,14 @@ public class DataCopyHelperTest {
   private HttpHeader getJsonContentTypeHeader() {
     HttpHeaderValue headerValue = new HttpHeaderValue("application/json");
     HttpHeader httpHeader = new HttpHeader("Content-Type");
+    httpHeader.setValues(Collections.singletonList(headerValue));
+    return httpHeader;
+  }
+
+  @NonNull
+  private HttpHeader getHeader() {
+    HttpHeaderValue headerValue = new HttpHeaderValue("headerValue");
+    HttpHeader httpHeader = new HttpHeader("Header");
     httpHeader.setValues(Collections.singletonList(headerValue));
     return httpHeader;
   }

--- a/Snooper/src/test/java/com/prateekj/snooper/networksnooper/helper/DataCopyHelperTest.java
+++ b/Snooper/src/test/java/com/prateekj/snooper/networksnooper/helper/DataCopyHelperTest.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 
 import static com.prateekj.snooper.utils.TestUtilities.getDate;
+import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -144,8 +145,12 @@ public class DataCopyHelperTest {
     String responseBody = "response body";
     String formatResponseBody = "format Response body";
 
+    HttpHeader httpHeader = getAcceptLanguageHttpHeader();
+
+    when(httpCall.getRequestHeaders()).thenReturn(asList(httpHeader, getJsonContentTypeHeader()));
     when(httpCall.getRequestHeader("Content-Type")).thenReturn(getJsonContentTypeHeader());
     when(httpCall.getPayload()).thenReturn(requestBody);
+    when(httpCall.getResponseHeaders()).thenReturn(asList(httpHeader, getJsonContentTypeHeader()));
     when(httpCall.getResponseHeader("Content-Type")).thenReturn(getJsonContentTypeHeader());
     when(httpCall.getResponseBody()).thenReturn(responseBody);
     when(httpCall.getDate()).thenReturn(getDate(2017, 4, 12, 1, 2, 3));
@@ -153,9 +158,11 @@ public class DataCopyHelperTest {
     when(responseFormatter.format(requestBody)).thenReturn(formatRequestBody);
     when(responseFormatter.format(responseBody)).thenReturn(formatResponseBody);
 
-
     StringBuilder httpCallData = dataCopyHelper.getHttpCallData();
-    assertThat(httpCallData.toString(), is("Request Body\nformat Request body\nResponse Body\nformat Response body"));
+
+    assertThat(httpCallData.toString(), is("Request Body\nformat Request body\nRequest Headers\naccept-language: en-US," +
+      "en;q=0.8,hi;q=0.6\nContent-Type: application/json\nResponse Body\nformat Response body\nResponse Headers\n" +
+      "accept-language: en-US,en;q=0.8,hi;q=0.6\nContent-Type: application/json\n"));
     verify(responseFormatter, times(1)).format(requestBody);
     verify(responseFormatter, times(1)).format(responseBody);
   }
@@ -167,6 +174,7 @@ public class DataCopyHelperTest {
 
     when(httpCall.getResponseHeader("Content-Type")).thenReturn(getJsonContentTypeHeader());
     when(httpCall.getResponseBody()).thenReturn(responseBody);
+    when(httpCall.getRequestHeaders()).thenReturn(null);
     when(httpCall.getDate()).thenReturn(getDate(2017, 4, 12, 1, 2, 3));
     when(formatterFactory.getFor("application/json")).thenReturn(responseFormatter);
     when(responseFormatter.format(responseBody)).thenReturn(formatResponseBody);
@@ -191,7 +199,7 @@ public class DataCopyHelperTest {
 
     StringBuilder httpCallData = dataCopyHelper.getHttpCallData();
 
-    assertThat(httpCallData.toString(), is("Request Body\nformat Request body\n"));
+    assertThat(httpCallData.toString(), is("Request Body\nformat Request body"));
     verify(responseFormatter, times(1)).format(requestBody);
   }
 
@@ -200,6 +208,16 @@ public class DataCopyHelperTest {
     HttpHeaderValue headerValue = new HttpHeaderValue("application/json");
     HttpHeader httpHeader = new HttpHeader("Content-Type");
     httpHeader.setValues(Collections.singletonList(headerValue));
+    return httpHeader;
+  }
+
+  @NonNull
+  private HttpHeader getAcceptLanguageHttpHeader() {
+    HttpHeader httpHeader = new HttpHeader("accept-language");
+    HttpHeaderValue value1 = new HttpHeaderValue("en-US,en");
+    HttpHeaderValue value2 = new HttpHeaderValue("q=0.8,hi");
+    HttpHeaderValue value3 = new HttpHeaderValue("q=0.6");
+    httpHeader.setValues(asList(value1, value2, value3));
     return httpHeader;
   }
 }


### PR DESCRIPTION
When clicking on share button, currently only request and response body is being shared. 
Requirement is to include headers as well in the data being shared.