### PR TITLE
Move writes to the DB to a background thread.

### DIFF
--- a/Snooper/src/main/java/com/prateekj/snooper/database/SnooperDbHelper.java
+++ b/Snooper/src/main/java/com/prateekj/snooper/database/SnooperDbHelper.java
@@ -3,6 +3,8 @@ package com.prateekj.snooper.database;
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
+import android.support.annotation.AnyThread;
+import android.support.annotation.MainThread;
 
 import static com.prateekj.snooper.networksnooper.database.HttpCallRecordContract.HEADER_CREATE_TABLE;
 import static com.prateekj.snooper.networksnooper.database.HttpCallRecordContract.HEADER_VALUE_CREATE_TABLE;
@@ -16,6 +18,7 @@ public class SnooperDbHelper extends SQLiteOpenHelper {
 
   private SnooperDbHelper(Context context) {
     super(context, DATABASE_NAME, null, DATABASE_VERSION);
+    super.setWriteAheadLoggingEnabled(true);
   }
 
   @Override
@@ -34,10 +37,23 @@ public class SnooperDbHelper extends SQLiteOpenHelper {
   public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
   }
 
+  @Override
+  public void setWriteAheadLoggingEnabled(boolean enabled) {
+    if(!enabled) {
+      throw new UnsupportedOperationException("Write ahead logging is required.");
+    }
+  }
+
+  @MainThread
   public static SnooperDbHelper getInstance(Context context) {
     if (mInstance == null) {
       mInstance = new SnooperDbHelper(context);
     }
     return mInstance;
+  }
+
+  @AnyThread
+  public static SnooperDbHelper create(Context context) {
+    return new SnooperDbHelper(context);
   }
 }


### PR DESCRIPTION
Writes to the DB on the main thread cause animation jitter if even a few small network requests are in progress.  I use this library for development builds in the application I work on (it's great by the way, thank you for making this open source), but a constant complaint from QA is that animations any kind of scrolling or dragging can become stuttered if a network request occurs at the same time.