### PR TITLE
Executes the builds much more quickly by Gradle Daemon

### DIFF
--- a/prePush.sh
+++ b/prePush.sh
@@ -1,1 +1,1 @@
-./gradlew clean testDebugUnitTest connectedDebugAndroidTest lintDebug assembleDebug --no-daemon
+./gradlew clean testDebugUnitTest connectedDebugAndroidTest lintDebug assembleDebug --daemon


### PR DESCRIPTION

[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
